### PR TITLE
Fix bug with enum too small

### DIFF
--- a/tests/1.8/regression/metadata/fail/enum-values-too-small/metadata
+++ b/tests/1.8/regression/metadata/fail/enum-values-too-small/metadata
@@ -1,7 +1,7 @@
 /* CTF 1.8 */
 typealias integer { size = 8; align = 8; signed = false; base = 10; } := uint8_t;
 typealias integer { size = 32; align = 32; signed = false; base = hex; } := uint32_t;
-typealias integer { size = 32; align = 32; signed = true; base = hex; } := TYPE;
+typealias integer { size = 8; align = 8; signed = true; base = hex; } := TYPE;
 
 trace {
 	major = 0;


### PR DESCRIPTION
The enum should be within 127, -128 with 8 bits
