### PR TITLE
Stress tests Python scripts: fix semantics

### DIFF
--- a/tests/1.8/stress/metadata/pass/large-metadata/test.py
+++ b/tests/1.8/stress/metadata/pass/large-metadata/test.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python3
-from ctftestsuite.stress import MetadataTest
+from ctftestsuite.stress import MetadataTestAssitant
 
 
-class Test(MetadataTest):
+class TestAssistant(MetadataTestAssitant):
     what = 'large metadata with {size} extra chars'
 
     def write_metadata(self, f):
@@ -25,5 +25,5 @@ class Test(MetadataTest):
 
 
 if __name__ == '__main__':
-    test = Test()
-    test.main()
+    test_assistant = TestAssistant()
+    test_assistant.main()

--- a/tests/1.8/stress/metadata/pass/long-identifier/test.py
+++ b/tests/1.8/stress/metadata/pass/long-identifier/test.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python3
-from ctftestsuite.stress import MetadataTest
+from ctftestsuite.stress import MetadataTestAssitant
 
 
-class Test(MetadataTest):
+class TestAssistant(MetadataTestAssitant):
     what = 'long identifier of {size} chars'
 
     def write_metadata(self, f):
@@ -28,5 +28,5 @@ class Test(MetadataTest):
 
 
 if __name__ == '__main__':
-    test = Test()
-    test.main()
+    test_assistant = TestAssistant()
+    test_assistant.main()

--- a/tests/1.8/stress/metadata/pass/many-callsites/test.py
+++ b/tests/1.8/stress/metadata/pass/many-callsites/test.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python3
-from ctftestsuite.stress import MetadataTest
+from ctftestsuite.stress import MetadataTestAssitant
 
 
-class Test(MetadataTest):
+class TestAssistant(MetadataTestAssitant):
     what = '{size} callsites'
 
     def write_metadata(self, f):
@@ -33,5 +33,5 @@ class Test(MetadataTest):
 
 
 if __name__ == '__main__':
-    test = Test()
-    test.main()
+    test_assistant = TestAssistant()
+    test_assistant.main()

--- a/tests/1.8/stress/metadata/pass/many-stream-class/test.py
+++ b/tests/1.8/stress/metadata/pass/many-stream-class/test.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python3
-from ctftestsuite.stress import MetadataTest
+from ctftestsuite.stress import MetadataTestAssitant
 
 
-class Test(MetadataTest):
+class TestAssistant(MetadataTestAssitant):
     what = '{size} stream classes'
 
     def write_metadata(self, f):
@@ -42,5 +42,5 @@ trace {
 
 
 if __name__ == '__main__':
-    test = Test()
-    test.main()
+    test_assistant = TestAssistant()
+    test_assistant.main()

--- a/tests/1.8/stress/metadata/pass/many-typealias/test.py
+++ b/tests/1.8/stress/metadata/pass/many-typealias/test.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python3
-from ctftestsuite.stress import MetadataTest
+from ctftestsuite.stress import MetadataTestAssitant
 
 
-class Test(MetadataTest):
+class TestAssistant(MetadataTestAssitant):
     what = '{size} typealiases'
 
     def write_metadata(self, f):
@@ -18,5 +18,5 @@ class Test(MetadataTest):
 
 
 if __name__ == '__main__':
-    test = Test()
-    test.main()
+    test_assistant = TestAssistant()
+    test_assistant.main()

--- a/tests/1.8/stress/metadata/pass/many-typedef/test.py
+++ b/tests/1.8/stress/metadata/pass/many-typedef/test.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python3
-from ctftestsuite.stress import MetadataTest
+from ctftestsuite.stress import MetadataTestAssitant
 
 
-class Test(MetadataTest):
+class TestAssistant(MetadataTestAssitant):
     what = '{size} typedefs'
 
     def write_metadata(self, f):
@@ -18,5 +18,5 @@ class Test(MetadataTest):
 
 
 if __name__ == '__main__':
-    test = Test()
-    test.main()
+    test_assistant = TestAssistant()
+    test_assistant.main()

--- a/utils/python/ctftestsuite/stress.py
+++ b/utils/python/ctftestsuite/stress.py
@@ -4,7 +4,7 @@ import sys
 import os
 
 
-class MetadataTest:
+class MetadataTestAssitant:
     BASIC_PROLOGUE = \
 '''/* CTF 1.8 */
 
@@ -48,7 +48,7 @@ trace {
 
         # validate size
         if args.size < 1:
-            MetadataTest._perror('wrong size: {}'.format(args.size))
+            MetadataTestAssitant._perror('wrong size: {}'.format(args.size))
 
         return args
 
@@ -79,7 +79,8 @@ trace {
 
     def _do_action(self):
         if self._action not in self._actions:
-            MetadataTest._perror('invalid action: "{}"'.format(self._action))
+            msg = 'invalid action: "{}"'.format(self._action)
+            MetadataTestAssitant._perror(msg)
 
         self._actions[self._action]()
 


### PR DESCRIPTION
`test.py` scripts do not test anything; they are test assistants. Class and variable names should reflect that.
